### PR TITLE
fix Go package path

### DIFF
--- a/apt/access/token_test.go
+++ b/apt/access/token_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudflared/apt-transport-cloudflare/apt/exec"
+	"github.com/cloudflare/apt-transport-cloudflared/apt/exec"
 )
 
 func TestHelperProcess(t *testing.T) {


### PR DESCRIPTION
The package path had contained a typo:

```console
$ GO111MODULE=off go test ./...
# github.com/cloudflare/apt-transport-cloudflared/apt/access
apt/access/token_test.go:9:2: cannot find package "github.com/cloudflared/apt-transport-cloudflare/apt/exec" in any of:
        /home/suda/gopath/src/github.com/cloudflare/apt-transport-cloudflared/vendor/github.com/cloudflared/apt-transport-cloudflare/apt/exec (vendor tree)
        /usr/local/go/src/github.com/cloudflared/apt-transport-cloudflare/apt/exec (from $GOROOT)
        /home/suda/gopath/src/github.com/cloudflared/apt-transport-cloudflare/apt/exec (from $GOPATH)
FAIL    github.com/cloudflare/apt-transport-cloudflared/apt/access [setup failed]
ok      github.com/cloudflare/apt-transport-cloudflared/apt     0.007s
?       github.com/cloudflare/apt-transport-cloudflared/apt/exec        [no test files]
?       github.com/cloudflare/apt-transport-cloudflared/cmd/cfd [no test files]
FAIL
```